### PR TITLE
Fix FileProvider Authority String to comply with Manifest declaration

### DIFF
--- a/app/src/main/java/com/example/android/commitcontent/ime/ImageKeyboard.java
+++ b/app/src/main/java/com/example/android/commitcontent/ime/ImageKeyboard.java
@@ -49,7 +49,7 @@ import java.io.OutputStream;
 public class ImageKeyboard extends InputMethodService {
 
     private static final String TAG = "ImageKeyboard";
-    private static final String AUTHORITY = "com.example.android.supportv13.sampleime.inputcontent";
+    private static final String AUTHORITY = "com.example.android.commitcontent.ime.inputcontent";
     private static final String MIME_TYPE_GIF = "image/gif";
     private static final String MIME_TYPE_PNG = "image/png";
     private static final String MIME_TYPE_WEBP = "image/webp";


### PR DESCRIPTION
Discrepancy between Manifest and ImageKeyboard file provider Authority string creates a null pointer exception in ImageKeyboard line 97 every time the keyboard is used.
